### PR TITLE
ci(gh-actions): Optimize workflow triggers to skip doc-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,25 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'assets/**'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.editorconfig'
+      - '.changeset/**'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'assets/**'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.editorconfig'
+      - '.changeset/**'
 
 jobs:
   build-and-test:


### PR DESCRIPTION

## 🚀 Summary
This PR optimizes the Continuous Integration (CI) pipeline by introducing `paths-ignore` rules. The workflow is now configured to skip resource-intensive builds and tests when a commit or pull request affects **only** documentation or static configuration files.

## 🛠️ Key Changes
Modified `.github/workflows/ci.yml` to ignore the following file patterns for both `push` and `pull_request` events:
- `**.md` (All Markdown files, including READMEs)
- `assets/**` (Images and static assets)
- `docs/**` (Documentation folder)
- `LICENSE`
- `.gitignore` & `.editorconfig`
- `.changeset/**`

## 📉 Benefits
- **Resource Efficiency:** Prevents wasting GitHub Actions minutes on non-code changes.
- **Reduced Noise:** Developers can update documentation without waiting for the full build/lint/test cycle.

## 🧪 How to Test
1. Merge this PR.
2. Create a new branch or commit that modifies **only** `README.md`.
3. Push the change.
4. Verify that the "CI / Build, Lint, and Test" workflow **does not trigger**.

## ✅ Checklist
- [x] YAML syntax is valid.
- [x] Logic covers both `push` and `pull_request` triggers.