### PR TITLE
ci(infra): Remove paths-ignore to prevent branch protection deadlocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,25 +4,10 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - 'assets/**'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.editorconfig'
-      - '.changeset/**'
+
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - 'assets/**'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.editorconfig'
-      - '.changeset/**'
 
 jobs:
   build-and-test:
@@ -40,7 +25,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: latest
 


### PR DESCRIPTION
### 🏗️ Infrastructure Change
Removes `paths-ignore` filters from the CI workflow.

### ❓ Motivation
Fixes a deadlock in Branch Protection Rules where "Build, Lint, and Test" is required but is skipped for documentation/release PRs, causing them to hang indefinitely.

### 📦 Changeset
No changeset required (CI config only).