### PR TITLE
chore(infra): Add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: 🐞 Bug report
+description: Report a reproducible bug in @cap-kit packages
+title: "[Bug]: "
+labels: ["bug"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug.
+        Please fill out all required fields to help us reproduce the issue.
+
+  - type: input
+    id: package
+    attributes:
+      label: Affected package
+      description: Which @cap-kit package is affected?
+      placeholder: "@cap-kit/camera"
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Package version
+      placeholder: "x.y.z"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      multiple: true
+      options:
+        - iOS
+        - Android
+        - Web
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Provide a minimal reproduction if possible.
+      placeholder: |
+        1. Install package
+        2. Call API
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Stack trace
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Discussions
+    url: https://github.com/<ORG>/<REPO>/discussions
+    about: Ask questions or start discussions here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: ✨ Feature request
+description: Suggest an idea or enhancement
+title: "[Feature]: "
+labels: ["feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature requests are welcome.
+        Please be as specific as possible.
+
+  - type: input
+    id: package
+    attributes:
+      label: Target package
+      placeholder: "@cap-kit/geolocation"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What problem does this feature address?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the solution you'd like to see.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: breaking
+    attributes:
+      label: Is this a breaking change?
+      options:
+        - "No"
+        - "Yes"
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## 📋 Description
+
+Explain what this PR changes and why.
+
+---
+
+## 🔗 Related issue
+
+Closes #
+
+---
+
+## 🧪 How has this been tested?
+
+- [ ] Unit tests
+- [ ] Manual testing
+- [ ] Not applicable
+
+---
+
+## ⚠️ Breaking changes
+
+- [ ] Yes
+- [ ] No
+
+If yes, describe the impact.
+
+---
+
+## 📦 Changeset required?
+
+- [ ] Yes
+- [ ] No
+
+> Reminder: any user-facing change **must include a changeset**.


### PR DESCRIPTION
### What
Introduces GitHub Issue Forms and a Pull Request template to standardize contributions.

### Why
Currently the repository provides no guidance when opening issues or PRs.
These templates improve issue quality, reduce triage time, and align with
other Capacitor ecosystem repositories.

### CI / Release impact
None.

### Changeset included
No.
