### PR TITLE
chore(infra): Add needs-reply workflow and stabilize CI pnpm version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: latest
+          version: 10
 
       - name: Get pnpm store directory
         shell: bash
@@ -37,10 +37,11 @@ jobs:
       - name: Setup pnpm cache
         uses: actions/cache@v3
         with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: |
+            ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-pnpm-
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/needs-reply.yml
+++ b/.github/workflows/needs-reply.yml
@@ -1,0 +1,38 @@
+name: Needs reply
+
+on:
+  schedule:
+    # Every day at 02:00 UTC
+    - cron: '0 2 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  needs-reply:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark issues and PRs that need a reply
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          days-before-stale: 14
+          days-before-close: -1
+
+          stale-issue-label: needs-reply
+          stale-pr-label: needs-reply
+
+          stale-issue-message: >
+            This issue has been marked as **needs-reply**.
+            Please provide additional information or feedback to keep it open.
+
+          stale-pr-message: >
+            This pull request has been marked as **needs-reply**.
+            Please provide the requested updates.
+
+          exempt-issue-labels: |
+            bug
+            feature
+            discussion
+
+          exempt-pr-labels: |
+            work-in-progress


### PR DESCRIPTION
### What
- Added a `needs-reply` GitHub Actions workflow to automatically label inactive
  issues and pull requests that require feedback.
- Fixed pnpm version in CI to avoid mismatches between local and CI environments.

### Why
- Improves issue and PR triage by preventing silent stalls.
- Ensures pnpm version parity, which is a strict requirement for this repository.

### CI / Release impact
- CI only: safer and more deterministic.
- No runtime or release impact.

### Changeset included
No.
