### PR TITLE
chore(infra): Add GitHub funding configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: fabiomartino


### PR DESCRIPTION
### What
Adds a GitHub funding configuration to enable the Sponsor button on the repository.

### Why
Provides a standard and non-intrusive way to support long-term maintenance
of the project, aligned with other Capacitor ecosystem repositories.

### CI / Release impact
None.

### Changeset included
No.
