### PR TITLE
ci(gh-actions): Limit build triggers to package and config changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,28 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'assets/**'
+      - '.vscode/**'
+      - '.idea/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.editorconfig'
 
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'assets/**'
+      - '.vscode/**'
+      - '.idea/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.editorconfig'
 
 jobs:
   build-and-test:
@@ -37,8 +55,7 @@ jobs:
       - name: Setup pnpm cache
         uses: actions/cache@v3
         with:
-          path: |
-            ~/.pnpm-store
+          path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-


### PR DESCRIPTION
 **What changed:**
Added `paths` filter to the CI workflow triggers.

 **Why:**
To optimize CI usage and skip expensive builds on documentation or non-code related changes.

 **Impact:**
CI will now only run when changes are detected in `packages/`, root config files, or lockfiles.

 **Changeset:**
No (Infra only).
