### PR TITLE
refactor(test-plugin)!: Rename Android namespace to io.capkit.test

### DIFF
--- a/.changeset/brown-apes-dig.md
+++ b/.changeset/brown-apes-dig.md
@@ -1,0 +1,5 @@
+---
+"@cap-kit/test-plugin": major
+---
+
+Breaking: Updated Android namespace from `com.capkit.test` to `io.capkit.test`. Consumers extending native classes must update their imports.

--- a/packages/test-plugin/android/build.gradle
+++ b/packages/test-plugin/android/build.gradle
@@ -46,7 +46,7 @@ def getPluginVersion() {
 def pluginVersion = getPluginVersion()
 
 android {
-    namespace = "com.capkit.test"
+    namespace = "io.capkit.test"
     compileSdk = project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion as Integer  : 36
 
     // AGP 8.0+ disables BuildConfig by default for libraries. 

--- a/packages/test-plugin/android/src/main/java/io/capkit/test/Logger.kt
+++ b/packages/test-plugin/android/src/main/java/io/capkit/test/Logger.kt
@@ -1,4 +1,4 @@
-package com.capkit.test
+package io.capkit.test
 
 import android.util.Log
 

--- a/packages/test-plugin/android/src/main/java/io/capkit/test/Test.kt
+++ b/packages/test-plugin/android/src/main/java/io/capkit/test/Test.kt
@@ -1,4 +1,4 @@
-package com.capkit.test
+package io.capkit.test
 
 /**
  * Native implementation for the Test Capacitor plugin.

--- a/packages/test-plugin/android/src/main/java/io/capkit/test/TestConfig.kt
+++ b/packages/test-plugin/android/src/main/java/io/capkit/test/TestConfig.kt
@@ -1,4 +1,4 @@
-package com.capkit.test
+package io.capkit.test
 
 import com.getcapacitor.Plugin
 

--- a/packages/test-plugin/android/src/main/java/io/capkit/test/TestPlugin.kt
+++ b/packages/test-plugin/android/src/main/java/io/capkit/test/TestPlugin.kt
@@ -1,4 +1,4 @@
-package com.capkit.test
+package io.capkit.test
 
 import com.getcapacitor.JSObject
 import com.getcapacitor.Plugin


### PR DESCRIPTION
## 🚀 Description
Refactors the Android project structure for `@cap-kit/test-plugin`.
- Renamed Java/Kotlin package from `com.capkit.test` to `io.capkit.test`.
- Updated `namespace` in `build.gradle`.
- Updated internal package declarations in source files.

## 💥 Breaking Changes
**YES**.
Any Android application consuming this plugin that explicitly imports `com.capkit.test.*` classes will break. Consumers must update their imports to `io.capkit.test.*`.

## 📦 Changeset
- [x] Included (Major)

## 🔍 Verification
- Verified local Android build passes with `io.capkit` namespace.