### PR TITLE
ci(release): Use GH_PAT to fix recursive workflow triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,6 @@ jobs:
           commit: "chore(release): Version packages"
           title: "chore(release): Version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## 📋 Summary
Updates the release workflow to use a Personal Access Token (`GH_PAT`) instead of the default `GITHUB_TOKEN`.
This change allows the Pull Requests created by the Changesets bot to trigger subsequent CI workflows (Build, Lint, Test), resolving the "Waiting for status to be reported" deadlock on protected branches.

## 🛠 Changes
* **.github/workflows/release.yml**: Swapped `secrets.GITHUB_TOKEN` for `secrets.GH_PAT` in the `changesets` step.

## ✅ Checklist
- [x] Secret `GH_PAT` added to repository settings
- [x] Workflow syntax verified
- [x] CI pipeline ready for next release