### PR TITLE
feat(settings): Initialize version 8.0.0

### DIFF
--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@cap-kit/settings",
-  "version": "0.0.1",
+  "version": "8.0.0-next.0",
   "description": "Capacitor plugin to open app and system settings on iOS and Android.",
   "type": "module",
-  "private": true,
+  "private": false,
   "engines": {
     "node": ">=24.0.0",
     "pnpm": ">=10.0.0"


### PR DESCRIPTION
 This PR prepares the `@cap-kit/settings` package for its first public release aligned with Capacitor v8.
 * Version bumped to 8.0.0-next.0.
 * Documentation updated via docgen.
 * Verified on Android and iOS.
 * Changeset included.
