### PR TITLE
ci(gh-actions): Enforce root README synchronization with package metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, 'renovate/**']
     paths-ignore:
-      - '**/*.md'
+      - 'packages/**/*.md'
       - 'docs/**'
       - 'assets/**'
       - 'LICENSE'
@@ -13,7 +13,7 @@ on:
   pull_request:
     branches: [main]
     paths-ignore:
-      - '**/*.md'
+      - 'packages/**/*.md'
       - 'docs/**'
       - 'assets/**'
       - 'LICENSE'
@@ -40,6 +40,11 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile # Prevents lockfile drift in CI
+
+      - name: Verify Root README sync
+        run: |
+          pnpm run readme:update
+          git diff --exit-code README.md || (echo "❌ Root README.md is out of sync with public packages. Run 'pnpm run readme:update' and commit the changes." && exit 1)
 
       - name: Lint (main)
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Description
This PR introduces a validation step in the Lint job to ensure the root README.md is always synchronized with the available public plugins.

## Changes
- Updated `ci.yml` to include a `git diff` check after running `pnpm run readme:update`.
- Adjusted `paths-ignore` to ensure the root README triggers CI validation.

## Impact
- **Consistency**: Guaranteed alignment between `packages/*/package.json` visibility and the root documentation table.
- **Changeset Included**: No.