### PR TITLE
Configure Renovate and automate changesets for dependency updates

### DIFF
--- a/.github/workflows/renovate-changeset.yml
+++ b/.github/workflows/renovate-changeset.yml
@@ -2,14 +2,16 @@ name: Renovate Changeset Helper
 
 on:
   pull_request:
-    branches:
-      - main
+    types: [opened, synchronize, labeled]
+    branches: [main]
 
 jobs:
   generate-changeset:
+    if: >
+      github.actor == 'renovate[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'requires-changeset')
     runs-on: ubuntu-latest
-    # Runs only if the actor is Renovate and the PR has the 'requires-changeset' label
-    if: github.actor == 'renovate[bot]' && contains(github.event.pull_request.labels.*.name, 'requires-changeset')
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -17,45 +19,50 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
 
-      - name: Detect Changed Packages and Create Changeset
-        shell: bash
+      - name: Ensure origin/main exists
         run: |
-          # 1. Find all modified package.json files (excluding the root one)
-          CHANGED_FILES=$(git diff --name-only origin/main...HEAD | grep "package.json" | grep "packages/" || true)
-          
-          if [ -z "$CHANGED_FILES" ]; then
-            echo "No package-level changes detected. Checking root dependencies..."
-            # If the change is only in the root, choose a default package (e.g. core)
-            # or apply different logic. Here we assume core as a fallback.
-            PACKAGES=("@cap-kit/core")
-          else
-            PACKAGES=()
-            for FILE in $CHANGED_FILES; do
-              # Extracts the "name" field from package.json using jq
-              PKG_NAME=$(jq -r '.name' $FILE)
-              PACKAGES+=("$PKG_NAME")
-            done
+          git fetch origin main:refs/remotes/origin/main || true
+
+      - name: Detect changed packages
+        id: packages
+        run: |
+          set -e
+
+          CHANGED=$(git diff --name-only origin/main...HEAD | grep '^packages/.*/package.json' || true)
+
+          if [ -z "$CHANGED" ]; then
+            echo "packages=[]" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
-          # 2. Create the changeset file
-          DESC="${{ github.event.pull_request.title }}"
-          FILENAME=".changeset/renovate-$(date +%s).md"
-          
-          echo "---" > $FILENAME
-          for PKG in "${PACKAGES[@]}"; do
-            echo "'$PKG': patch" >> $FILENAME
-          done
-          echo "---" >> $FILENAME
-          echo "" >> $FILENAME
-          echo "$DESC" >> $FILENAME
-          
-          echo "✅ Created changeset for: ${PACKAGES[*]}"
+          PKGS=$(for f in $CHANGED; do jq -r '.name' "$f"; done | jq -R . | jq -s .)
+          echo "packages=$PKGS" >> $GITHUB_OUTPUT
 
-      - name: Commit Changeset
+      - name: Create changeset
+        if: steps.packages.outputs.packages != '[]'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          set -e
+
+          FILENAME=".changeset/renovate-${{ github.event.pull_request.number }}.md"
+          TITLE="${{ github.event.pull_request.title }}"
+
+          echo "---" > "$FILENAME"
+
+          for PKG in $(echo '${{ steps.packages.outputs.packages }}' | jq -r '.[]'); do
+            echo "'$PKG': patch" >> "$FILENAME"
+          done
+
+          echo "---" >> "$FILENAME"
+          echo "" >> "$FILENAME"
+          echo "$TITLE" >> "$FILENAME"
+
+          cat "$FILENAME"
+
+      - name: Commit changeset
+        if: steps.packages.outputs.packages != '[]'
+        run: |
+          git config user.name "renovate[bot]"
+          git config user.email "renovate[bot]@users.noreply.github.com"
           git add .changeset/*.md
-          # [skip ci] prevents infinite CI pipeline loops
-          git commit -m "chore(release): Add dynamic changeset for renovate update [skip ci]"
+          git commit -m "chore(release): add changeset for renovate update"
           git push

--- a/renovate.json
+++ b/renovate.json
@@ -1,24 +1,39 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
   "extends": [
     "config:recommended",
     "schedule:earlyMondays",
-    ":preserveSemverRanges",
-    "group:allNonMajor"
+    ":preserveSemverRanges"
   ],
+
   "dependencyDashboard": true,
+
+  "labels": ["dependencies"],
+
+  "pnpm": {
+    "enabled": true
+  },
+
+  "constraints": {
+    "node": ">=24.0.0",
+    "pnpm": ">=10.0.0"
+  },
+
   "lockFileMaintenance": {
     "enabled": true,
+    "schedule": ["before 6am on monday"],
     "automerge": true
   },
+
   "packageRules": [
     {
-      "description": "Disable updates for our internal packages",
+      "description": "Never update internal workspace packages",
       "matchPackageNames": ["@cap-kit/*"],
       "enabled": false
     },
     {
-      "description": "Peer dependency protection for Capacitor v8+",
+      "description": "Capacitor peer deps: widen only, never bump major implicitly",
       "matchDepTypes": ["peerDependencies"],
       "matchPackageNames": [
         "@capacitor/core",
@@ -28,23 +43,16 @@
       "rangeStrategy": "widen"
     },
     {
-      "description": "Safe automerge for non-major devDependencies",
-      "matchUpdateTypes": ["patch", "minor"],
+      "description": "Group non-major devDependencies (no automerge, visible PRs)",
       "matchDepTypes": ["devDependencies"],
-      "automerge": true,
-      "labels": ["dependencies", "automerge"]
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "devDependencies (non-major)",
+      "automerge": false
     },
     {
       "description": "Require changeset for production dependencies",
       "matchDepTypes": ["dependencies"],
-      "labels": ["dependencies", "requires-changeset"]
+      "labels": ["requires-changeset"]
     }
-  ],
-  "constraints": {
-    "node": ">=24.0.0",
-    "pnpm": ">=10.0.0"
-  },
-  "pnpm": {
-    "enabled": true
-  }
+  ]
 }


### PR DESCRIPTION
### **Description**

This PR sets up and stabilizes Renovate for the pnpm-based monorepo and integrates it cleanly with Changesets.

#### ✨ What’s included

* Added a **Renovate configuration** tailored for a pnpm monorepo
* Enabled a **Dependency Dashboard** for full visibility into dependency updates
* Introduced clear scheduling (early Mondays) and safer grouping rules
* Disabled updates for internal workspace packages
* Added a GitHub Actions workflow that **automatically generates Changesets**
  when Renovate updates production dependencies

#### 🧠 Why

* Makes dependency updates predictable and transparent
* Avoids silent automerges and unclear version bumps
* Ensures all production dependency updates are correctly tracked via Changesets
* Keeps CI and release flow consistent as the plugin suite grows

#### 🔍 Notes

* Renovate runs as a GitHub App (not as a GitHub Action)
* Configuration is read from `main`, so changes take effect after merge
* The first Renovate run may take a few minutes after this PR is merged
