### PR TITLE
fix(gradle): Make kotlin-android plugin application conditional

### DIFF
--- a/packages/integrity/android/build.gradle
+++ b/packages/integrity/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:9.2.0'
+        classpath 'com.android.tools.build:gradle:9.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -23,7 +23,9 @@ ext {
 }
 
 apply plugin: 'com.android.library'
-// apply plugin: 'kotlin-android'
+if (project.extensions.findByName('kotlin') == null) {
+    apply plugin: 'kotlin-android'
+}
 apply plugin: 'kotlin-parcelize'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 

--- a/packages/people/android/build.gradle
+++ b/packages/people/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:9.2.0'
+        classpath 'com.android.tools.build:gradle:9.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -23,7 +23,9 @@ ext {
 }
 
 apply plugin: 'com.android.library'
-// apply plugin: 'kotlin-android'
+if (project.extensions.findByName('kotlin') == null) {
+    apply plugin: 'kotlin-android'
+}
 apply plugin: 'kotlin-parcelize'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 

--- a/packages/rank/android/build.gradle
+++ b/packages/rank/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:9.2.0'
+        classpath 'com.android.tools.build:gradle:9.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -23,7 +23,9 @@ ext {
 }
 
 apply plugin: 'com.android.library'
-// apply plugin: 'kotlin-android'
+if (project.extensions.findByName('kotlin') == null) {
+    apply plugin: 'kotlin-android'
+}
 apply plugin: 'kotlin-parcelize'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 

--- a/packages/redsys/android/build.gradle
+++ b/packages/redsys/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:9.2.0'
+        classpath 'com.android.tools.build:gradle:9.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -23,7 +23,9 @@ ext {
 }
 
 apply plugin: 'com.android.library'
-// apply plugin: 'kotlin-android'
+if (project.extensions.findByName('kotlin') == null) {
+    apply plugin: 'kotlin-android'
+}
 apply plugin: 'kotlin-parcelize'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 

--- a/packages/settings/android/build.gradle
+++ b/packages/settings/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:9.2.0'
+        classpath 'com.android.tools.build:gradle:9.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -23,7 +23,9 @@ ext {
 }
 
 apply plugin: 'com.android.library'
-// apply plugin: 'kotlin-android'
+if (project.extensions.findByName('kotlin') == null) {
+    apply plugin: 'kotlin-android'
+}
 apply plugin: 'kotlin-parcelize'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 

--- a/packages/tls-fingerprint/android/build.gradle
+++ b/packages/tls-fingerprint/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:9.2.0'
+        classpath 'com.android.tools.build:gradle:9.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -23,7 +23,9 @@ ext {
 }
 
 apply plugin: 'com.android.library'
-// apply plugin: 'kotlin-android'
+if (project.extensions.findByName('kotlin') == null) {
+    apply plugin: 'kotlin-android'
+}
 apply plugin: 'kotlin-parcelize'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 


### PR DESCRIPTION
Summary:
This PR updates the build.gradle configuration across all subpackages to make the application of the kotlin-android plugin conditional.
Context:
During the upgrade to Gradle 9.5.1 and the associated Android Gradle Plugin (AGP) updates, build failures occurred because the kotlin-android plugin is no longer required for Kotlin support in newer AGP versions. Simply removing it might break older build contexts, so this change ensures the plugin is only applied if not already present.
Changes:
- Modified packages/*/android/build.gradle files to conditionally apply kotlin-android.
- This resolves build conflicts related to plugin redundancy while maintaining compatibility with the current build environment.
Verification:
- Verified that pnpm run verify:android now executes successfully after applying the conditional logic to the build.gradle files.
- Confirmed the build no longer fails due to the "plugin no longer required" error.